### PR TITLE
fix URL

### DIFF
--- a/source/includes/_repositories.html.md
+++ b/source/includes/_repositories.html.md
@@ -8,7 +8,7 @@
 curl \
   -H "Accept: application/vnd.api+json" \
   -H "Authorization: Token token={TOKEN}" \
-  https://api.codeclimate.com/repos?github_slug=twinpeaks/ranchorosa
+  https://api.codeclimate.com/v1/repos?github_slug=twinpeaks/ranchorosa
 ```
 
 > Alternatively, if you know the repo_id, you can issue the following:


### PR DESCRIPTION
Update URL in "Retrieve a repo by github_slug" example

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->