### PR TITLE
Add vcs_database_id and vcs_host to docs

### DIFF
--- a/source/includes/_repositories.html.md
+++ b/source/includes/_repositories.html.md
@@ -36,6 +36,8 @@ curl \
         "github_slug": "twinpeaks\/ranchorosa",
         "human_name": "ranchorosa",
         "last_activity_at": "2017-07-15T20:09:41.846Z",
+        "vcs_database_id": "92872343",
+        "vcs_host": "https://github.com",
         "score": 1.36
       },
       "relationships": {
@@ -402,6 +404,8 @@ $ curl \
       "github_slug": "twinpeaks\/ranchorosa",
       "human_name": "brew",
       "last_activity_at": "2017-07-25T21:05:34.827Z",
+      "vcs_database_id": "92872343",
+      "vcs_host": "https://github.com",
       "score": null
     },
     "relationships": {
@@ -481,6 +485,8 @@ curl \
       "github_slug": "twinpeaks\/ranchorosa",
       "human_name": "ranchorosa",
       "last_activity_at": "2017-07-15T20:09:41.846Z",
+      "vcs_database_id": "92872343",
+      "vcs_host": "https://github.com",
       "score": 1.36
     },
     "relationships": {


### PR DESCRIPTION
This adds `vcs_database_id` and `vcs_host` to the docs for the `v1/repos` endpoint.
