### PR TITLE
QUA-51: Update docs to include lines_of_code in snapshots and test reports

### DIFF
--- a/source/includes/_repository_analysis.html.md
+++ b/source/includes/_repository_analysis.html.md
@@ -392,6 +392,7 @@ curl \
       "commit_sha": "db36165a645accc5ac78d3c70dffffa4aef7d8a2",
       "committed_at": "2017-07-14T20:00:26.765Z",
       "created_at": "2017-07-14T20:03:14.042Z",
+      "lines_of_code": 456,
       "ratings": [
         {
           "letter": "A",

--- a/source/includes/_test_coverage.html.md
+++ b/source/includes/_test_coverage.html.md
@@ -24,6 +24,7 @@ curl
         "commit_sha": "cd3811626d5f723130417735d10a132f285795cc",
         "committed_at": "2017-07-16T02:55:52.000Z",
         "covered_percent": 84.946657957762,
+        "lines_of_code": 456,
         "rating": {
           "path": "\/",
           "letter": "B",


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
Related to https://github.com/codeclimate/api/pull/632